### PR TITLE
BACKLOG-12502 expose uiExtender and i18n in a global variable to be able to extend the UI with a simple JS file

### DIFF
--- a/src/javascript/main.js
+++ b/src/javascript/main.js
@@ -15,7 +15,7 @@ require('whatwg-fetch');
 const uiExtender = require('@jahia/ui-extender');
 require('@jahia/moonstone');
 require('@jahia/data-helper');
-require('./i18n');
+import i18n from './i18n/i18n';
 require('./apollo/register');
 // DEPRECATED JAHIA PACKAGES
 require('@jahia/design-system-kit');
@@ -42,6 +42,10 @@ const jsload = path => new Promise(resolve => {
 });
 
 export default function (js, appshellmode) {
+    window.jahia = {
+        uiExtender: uiExtender,
+        i18n: i18n
+    };
     if (appshellmode) {
         // Load main scripts for each bundle
         let jsloads = js.map(path => {


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/BACKLOG-12502

## Description
Expose uiExtender and i18n in a global variable to be able to extend the UI with a simple JS file

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist
I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation
- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
